### PR TITLE
Fix: Space after `package`

### DIFF
--- a/plugin/vimport.vim
+++ b/plugin/vimport.vim
@@ -183,6 +183,7 @@ function! CreateImports(pathList)
         endif
         if (g:vimport_auto_organize)
             :call OrganizeImports()
+            :call SpaceAfterPackage()
         endif
     endif
 endfunction
@@ -329,6 +330,29 @@ function! OrganizeImports()
     call setpos('.', pos)
 endfunction
 command! OrganizeImports :call OrganizeImports()
+
+function! SpaceAfterPackage()
+    :let pos = getpos('.')
+
+    :execute "normal gg"
+    :let packageStart = search("^package")
+    if packageStart == 0
+        return
+    endif
+
+    :let importStart = search("^import")
+    if importStart == 0
+        return
+    endif
+
+    :let expectedImportStart = (packageStart + 2)
+    if importStart != expectedImportStart
+        :execute "normal O"
+    endif
+
+    call setpos('.', pos)
+endfunction
+command! SpaceAfterPackage :call SpaceAfterPackage()
 
 function! GrabImportBlock()
 


### PR DESCRIPTION
OrganizeImports was removing the space between package and the first import line.

Example:

```
package org.zirbes.bobbyconf
import org.zirbes.bobbyconf.js.node.Nan
import org.zirbes.bobbyconf.js.angular.DirectThis
import org.zirbes.bobbyconf.js.react.PutTheHtmlWhere
```

This ensures there is always a space between the two
